### PR TITLE
"FIX" for KeyError when using multiprocessing to run http/https

### DIFF
--- a/tornado/ioloop.py
+++ b/tornado/ioloop.py
@@ -835,17 +835,18 @@ class PollIOLoop(IOLoop):
                 self._events.update(event_pairs)
                 while self._events:
                     fd, events = self._events.popitem()
-                    try:
-                        fd_obj, handler_func = self._handlers[fd]
-                        handler_func(fd_obj, events)
-                    except (OSError, IOError) as e:
-                        if errno_from_exception(e) == errno.EPIPE:
-                            # Happens when the client closes the connection
-                            pass
-                        else:
+                    if fd in self._handlers: 
+                        try:
+                            fd_obj, handler_func = self._handlers[fd]
+                            handler_func(fd_obj, events)
+                        except (OSError, IOError) as e:
+                            if errno_from_exception(e) == errno.EPIPE:
+                                # Happens when the client closes the connection
+                                pass
+                            else:
+                                self.handle_callback_exception(self._handlers.get(fd))
+                        except Exception:
                             self.handle_callback_exception(self._handlers.get(fd))
-                    except Exception:
-                        self.handle_callback_exception(self._handlers.get(fd))
                 fd_obj = handler_func = None
 
         finally:


### PR DESCRIPTION
When using python multiprocessing to run Tornado with two servers in separate processes, a key error is continually thrown. As of yet this key error does not appear to affect the the functionality, but it does fill the log up pretty quick.

```
Exception in callback None
Traceback (most recent call last):
  File "/venv/lib/python3.4/site-packages/tornado/ioloop.py", line 839, in start
    fd_obj, handler_func = self._handlers[fd]
KeyError: 14
```

Here is the code I am using to  start the server. If I use only one process, the issue does not occur. 

```python
class webApp(web.Application):
    def __init__(self, routes, test=False):
        if test:
            settings["debug"] = False
            settings["xsrf_cookies"] = False
        super(webApp, self).__init__(routes, **settings)
        self.db = session


class Application(httpserver.HTTPServer):
    def __init__(self, application, ssl_options=False):
        if ssl_options:
            super(Application, self).__init__(application, ssl_options=ssl_options)
            self.listen(secure_port)
        else:
            super(Application, self).__init__(application)
            self.listen(port)
        self.io_loop = ioloop.IOLoop.instance()

    def run(self):
        self.io_loop.start()

    def stop(self):
        self.io_loop.stop()


def start_server(app, ssl_options=False):
    app = Application(app, ssl_options)
    app.run()


if __name__ == "__main__":
    # set up seperate processes for http and https
    s1 = Process(target=start_server, args=(webApp(routes),))
    s2 = Process(target=start_server, args=(webApp(routes), ssl_options))
    # start each server
    s1.start()
    s2.start()
    # join the processes
    s1.join()
    s2.join()
    # start_server(webApp(routes));
```

If I the code is altered to add in print statements, one can get a little further back on the traceback.

```python

#tornado/ioloop.py [lines 836-852]

self._events.update(event_pairs)
while self._events:
    fd, events = self._events.popitem()
    print(fd)
    print(self._handlers)
    print(self._handlers[fd])
    try:
        fd_obj, handler_func = self._handlers[fd]
        handler_func(fd_obj, events)
    except (OSError, IOError) as e:
        if errno_from_exception(e) == errno.EPIPE:
            # Happens when the client closes the connection
            pass
        else:
            self.handle_callback_exception(self._handlers.get(fd))
    except Exception:
        self.handle_callback_exception(self._handlers.get(fd))
fd_obj = handler_func = None
```

Here is the info/error returned from that change:

```
11
{12: (<socket.socket fd=12, family=AddressFamily.AF_INET6, type=2049, proto=6, laddr=('::', 8889, 0, 0)>, <function wrap.<locals>.null_wrapper at 0x7f9a2d5479d8>), 13: (<socket.socket fd=13, family=AddressFamily.AF_INET, type=2049, proto=6, laddr=('0.0.0.0', 8889)>, <function wrap.<locals>.null_wrapper at 0x7f9a2d547a60>), 6: (6, <function wrap.<locals>.null_wrapper at 0x7f9a2d547730>)}
Process Process-2:
Traceback (most recent call last):
  File "/usr/lib/python3.4/multiprocessing/process.py", line 254, in _bootstrap
    self.run()
  File "/usr/lib/python3.4/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "server.py", line 56, in start_server
    app.run()
  File "server.py", line 33, in run
    self.io_loop.start()
  File "/venv/lib/python3.4/site-packages/tornado/ioloop.py", line 840, in start
    print(self._handlers[fd])
KeyError: 11
```